### PR TITLE
build.gradle - needs spring boot plugin to start application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'org.springframework.boot' version '2.1.9.RELEASE'
 }
 
 repositories {


### PR DESCRIPTION
I built latest `develop` and running the built JAR and got the following error. I was able to fix it by adding the 'org.springframework.boot' plugin at the same version as connector-channel.

```
$ ./gradlew clean assemble && java -jar ./build/libs/*.jar
Starting a Gradle Daemon (subsequent builds will be faster)

BUILD SUCCESSFUL in 14s
4 actionable tasks: 4 executed
no main manifest attribute, in ./build/libs/ph-ee-connector-gsma-1.0.0-SNAPSHOT.jar

```
